### PR TITLE
Remove unused imports triggering import errors

### DIFF
--- a/src/redfish/rest/connections.py
+++ b/src/redfish/rest/connections.py
@@ -16,13 +16,11 @@
 
 # -*- coding: utf-8 -*-
 """All Connections for interacting with REST."""
-import os
 import time
 import gzip
 import json
 import logging
 import urllib3
-import certifi
 
 from urllib3 import ProxyManager, PoolManager
 from urllib3.exceptions import MaxRetryError, DecodeError

--- a/src/redfish/rest/containers.py
+++ b/src/redfish/rest/containers.py
@@ -18,7 +18,6 @@
 """Containers used for REST requests and responses."""
 import sys
 import json
-import six
 
 try:
     from collections import OrderedDict

--- a/src/redfish/ris/ris.py
+++ b/src/redfish/ris/ris.py
@@ -24,7 +24,6 @@ import re
 from re import error as regexerr
 
 import sys
-import weakref
 import logging
 import threading
 # Added for py3 compatibility
@@ -241,8 +240,7 @@ class RisMonolith(Dictable):
     """Monolithic cache of RIS data. This takes a :class:`redfish.rest.v1.RestClient` and uses it to
     gather data from a server and saves it in a modifiable database called monolith.
 
-    :param client: client to use for data retrieval. Client is saved as a weakref, using it requires
-                   parenthesis and will not survive if the client used in init is removed.
+    :param client: client to use for data retrieval.
     :type client: :class:`redfish.rest.v1.RestClient`
     :param typepath: The compatibility class to use for differentiating between Redfish/LegacyRest.
     :type typepath: :class:`redfish.rest.ris.Typesandpathdefines`

--- a/src/redfish/ris/validation.py
+++ b/src/redfish/ris/validation.py
@@ -24,14 +24,8 @@ import six
 import json
 import logging
 import textwrap
-import jsonpath_rw
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from collections.abc import OrderedDict
 from redfish.rest.containers import RisObject
-from redfish.ris.utils import json_traversal
 from .sharedtypes import JSONEncoder
 
 # ---------End of imports---------


### PR DESCRIPTION


-----Synopsis of Commits Above-----

**Please fill out the following when submitting the PR**

## Status
- [x] READY 
- [ ] IN-DEVELOPMENT 
- [ ] ON-HOLD

## Additional High Level Description

When running the examples in a fresh virtualenv they fail with an import error due `certifi` not being in `requirements.txt`.
But `certifi` (and some other modules) are actually not used.

## Before Status can be set to READY I have completed the following:
- [x] Check if documentation updates
- [x] Check if example code updates
- [x] Pylint static analysis tests are passing above 9.0/10.0
- [x] Unit tests added for any new functions/features and passed.
- [x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.
